### PR TITLE
fix compile error  ”unknown type name ‘uint32_t’“  using gcc4.8.2

### DIFF
--- a/src/digest.c
+++ b/src/digest.c
@@ -17,7 +17,7 @@
  */
 
 #include "pmurhashAPI.h"
-
+#include <stdint.h>
 const uint32_t 
   MURMURHASH3_H_SEED = 3120602769LL,
   MURMURHASH3_XI_SEED = 79193439LL;


### PR DESCRIPTION
fix compile error  ”unknown type name ‘uint32_t’“  using gcc4.8.2
![image](https://cloud.githubusercontent.com/assets/1319585/14880566/10fdaa04-0d62-11e6-8409-076fc6e18e97.png)
